### PR TITLE
fix(android): reject the promise on SDK errors instead of crashing the app

### DIFF
--- a/android/src/main/java/expo/modules/yoco/ReactNativeYocoModule.kt
+++ b/android/src/main/java/expo/modules/yoco/ReactNativeYocoModule.kt
@@ -72,8 +72,8 @@ class ReactNativeYocoModule : Module() {
 
                 YocoSDK.pairTerminal(context = currentActivity)
             } catch (e: Exception) {
+                pairTerminalPromise = null
                 promise.reject(e.toCodedException())
-                throw e
             }
         }
 
@@ -106,8 +106,8 @@ class ReactNativeYocoModule : Module() {
                     null,
                 )
             } catch (e: Exception) {
+                chargePromise = null
                 promise.reject(e.toCodedException())
-                throw e
             }
         }
 
@@ -188,8 +188,8 @@ class ReactNativeYocoModule : Module() {
                     null,
                 )
             } catch (e: Exception) {
+                refundPromise = null
                 promise.reject(e.toCodedException())
-                throw e
             }
         }.runOnQueue(Queues.MAIN)
 

--- a/android/src/main/java/expo/modules/yoco/data/result/ReactNativeYocoPaymentResult.kt
+++ b/android/src/main/java/expo/modules/yoco/data/result/ReactNativeYocoPaymentResult.kt
@@ -7,6 +7,8 @@ import expo.modules.yoco.enums.*
 class ReceiptInfo : Record {
     @Field
     var authorizationCode: String? = null
+
+    @Field
     var transactionTime: String? = null
 
     fun injectValues(receiptInfo: com.yoco.payments.sdk.data.result.ReceiptInfo?): ReceiptInfo {


### PR DESCRIPTION
## The bug

`pairTerminal`, `charge` and `refund` all do this:

```kotlin
} catch (e: Exception) {
    promise.reject(e.toCodedException())
    throw e                              // ← escapes the module
}
```

Rejecting is correct. The rethrow then sends the same exception out of the module's coroutine — and for `refund`, which is `.runOnQueue(Queues.MAIN)`, out on the main queue. So an error the JS side is fully equipped to handle instead takes the process down.

Seen in production (Sally POS, Yoco terminals):

- on a device where `YocoSDK.initialise()` had failed (its Koin graph couldn't build `BaseURLsConfigProvider`), every later SDK call threw — pressing **Void** killed the app instead of showing "could not start refund";
- a charge that rounded to `amountInCents: 0` hit `IllegalArgumentException: Amount provided needs to be a positive number` and did the same.

Both are ordinary, recoverable errors on the JS side. Neither should be fatal.

## The change

- drop the `throw e` in the three `AsyncFunction` catch blocks — the promise rejection is the error channel;
- null the stored promise on the failure path. `chargePromise` / `refundPromise` / `pairTerminalPromise` are otherwise only cleared in the `OnActivityResult` handlers, so a rejected-but-retained promise could later be resolved by an unrelated activity result, settling it twice (a crash of its own under the New Architecture);
- `configure` **keeps** its rethrow — it's a synchronous `Function`, where throwing is how the error reaches JS. That path is what surfaces the init failure to the app, and it should stay.

## Second, unrelated one-liner

`ReceiptInfo.transactionTime` is missing `@Field`, so it never serialises into the JS payment result on Android — anything reading `receiptInfo.transactionTime` silently gets `undefined`. iOS exposes it. Added the annotation.

## Verified against the SDK

Decompiled `com.yoco:payment-ui:2.6.9` from the Gradle cache to confirm the surrounding assumptions (Yoco's docs site currently 404s on every `developer.yoco.com/in-person/android/*` page through its redirect to `yoco.docs.buildwithfern.com`):

- `public void refund(Context, String transactionId, RefundParameters, PrintParameters, ActivityResultLauncher)` — the parameter is named `transactionId`, and the method throws `IllegalArgumentException("An empty transaction cannot be refunded")` on a blank id. It is **not** the `clientTransactionId`; `PaymentResult` carries both separately, and this module already surfaces both.
- No behavioural change to any success path here — only what happens when a launch throws.

## Testing

Not covered by automated tests (the module has none, and this is native error-path behaviour). Reviewed by inspection; the intended result is that a failing `charge`/`refund`/`pairTerminal` arrives in JS as a rejected promise carrying the SDK's message, with the app still running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recovery after terminal pairing, charging, or refund failures by resetting the operation state.
  - Prevented failed payment operations from producing duplicate or unexpected error propagation.
  - Receipt details now correctly include the transaction time when displayed or processed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->